### PR TITLE
fix typo of type

### DIFF
--- a/src/browsers/chromium-based-browsers.ts
+++ b/src/browsers/chromium-based-browsers.ts
@@ -46,7 +46,7 @@ export interface CustomEmulatedDevice {
   }
   modes: Array<{
     title: string
-    orientation: 'vertical' | 'hotizontal'
+    orientation: 'vertical' | 'horizontal'
     insets: Insets
   }>
   'show-by-default': boolean


### PR DESCRIPTION
The actually expected type is `string`
https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/front_end/models/emulation/EmulatedDevices.ts;l=612;drc=69beff3aa31dacfe40db878ef7bfa27e04393be1
The actual code used these values.
https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/front_end/models/emulation/EmulatedDevices.ts;l=462-465;drc=69beff3aa31dacfe40db878ef7bfa27e04393be1