### PR TITLE
fix: resolve find-process ESM/CJS interop issue causing TypeError

### DIFF
--- a/src/utils/chromium-based-browsers.ts
+++ b/src/utils/chromium-based-browsers.ts
@@ -89,8 +89,13 @@ export class ChromePreference {
     async isLaunching (name: string = ''): Promise<boolean> {
         const browser = this.getBrowser(name)
         const processName = BROWSER_PROCESS_NAME[browser]
+        // find-process v2 exports via `exports.default` (CJS). Depending on the
+        // Node.js version, ESM importing CJS may give the module.exports object
+        // (find.default is the function) or unwrap __esModule and give the
+        // function directly. Handle both cases.
+        const findFn = find.default ?? (find as unknown as typeof find.default)
         return new Promise(resolve => {
-            find.default('name', processName)
+            findFn('name', processName)
                 .then((list: ProcessInfo[]) => {
                     resolve(list.some(i => i.name === processName))
                 }).catch((error: unknown) => {


### PR DESCRIPTION
find-process v2 exports its function via `exports.default` (CJS with
__esModule: true). Depending on the Node.js version, importing this from
an ESM module may yield either the module.exports object (where
find.default is the function) or the unwrapped function directly.

Use `find.default ?? find` to handle both cases, fixing the
"find.default is not a function" error reported in issue #25.

https://claude.ai/code/session_01EQvqtiaHTAsZXKxY85qVjW